### PR TITLE
filter env list based on names

### DIFF
--- a/progs/init-conda.scm
+++ b/progs/init-conda.scm
@@ -31,7 +31,10 @@
                  (python-entry)))
 
 (define (other-conda-launchers)
-  (map (lambda (name) (list :launch name (conda-launcher name))) (cdr (conda-versions))))
+  (map (lambda (name) (list :launch name (conda-launcher name)))
+       (filter
+         (lambda (x) (not (== x "base")))
+         (conda-versions))))
 
 (define (conda-launchers)
   (cons (list :launch (conda-launcher "base"))


### PR DESCRIPTION
On my systems the "base" env is not first in the list from `conda env list`, so filtering needs to be done base on the name, not the order in the list.